### PR TITLE
Workaround for a codec that is slow coming out of reset

### DIFF
--- a/src/tlv320aic31xx_codec.cpp
+++ b/src/tlv320aic31xx_codec.cpp
@@ -236,11 +236,16 @@ bool TLV320AIC31xx::begin() {
 
 bool TLV320AIC31xx::isConnected() {
 #ifdef ARDUINO
-  this->twowire->beginTransmission(TLV320AIC31XX_I2C_ADDRESS);
-  if (this->twowire->endTransmission() != 0)
-    return false; // codec did not ACK
-#endif
+  for(int tries=0;tries<10;tries++) {
+    this->twowire->beginTransmission(TLV320AIC31XX_I2C_ADDRESS);
+    if (this->twowire->endTransmission() == 0)
+      return true; // codec ACK'ed
+    delay(10);
+  }
+  return false; // codec did not ACK
+#else
   return true;
+#endif
 }
 
 // Function to write a single register


### PR DESCRIPTION
Change-Id: I53013bd8271aef26ff711be66ec68f867182a0a9

Adds a for loop in TLV320AIC31xx::isConnected() to try the initial I2C comm 10 times to workaround a slow to recover from reset codec chip.  As soon as the codec responds, the function will return true, or return false if the loop times out.